### PR TITLE
make nicknames optional

### DIFF
--- a/src/client/components/Media.tsx
+++ b/src/client/components/Media.tsx
@@ -100,7 +100,6 @@ export class MediaForm extends React.PureComponent<MediaProps> {
     return (
       <form className='media' onSubmit={this.handleSubmit}>
         <input
-          required
           name='nickname'
           type='text'
           placeholder='Nickname'


### PR DESCRIPTION
Make nicknames fully optional by removing the annoying `required` HTML attribute of the input field.

This saves some time and means less room for user error.

As of right now, using the "Inspect" function of a browser to manually remove the attribute works just fine and the nickname will simply be automatically generated (like this *07a4cfc9-7642-5ec8-9c75-7e27d61be2ff*)