### PR TITLE
Add support for end-to-end encryption using Insertable Streams and Web Crypto API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10314,9 +10314,9 @@
       "dev": true
     },
     "queue-microtask": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.2.tgz",
-      "integrity": "sha512-F9wwNePtXrzZenAB3ax0Y8TSKGvuB7Qw16J30hspEUTbfUM+H827XyN3rlpwhVmtm5wuZtbKIHjOnwDn7MUxWQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
+      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA==",
       "dev": true
     },
     "randombytes": {
@@ -11504,8 +11504,8 @@
       "dev": true
     },
     "simple-peer": {
-      "version": "git+https://github.com/jeremija/simple-peer.git#82fdb34074cbf09048440663e519efae10d11576",
-      "from": "git+https://github.com/jeremija/simple-peer.git#transceiver-mid",
+      "version": "git+https://github.com/jeremija/simple-peer.git#0d0f338d3cddf35732e5d7d50c231d0f9de5b8e0",
+      "from": "git+https://github.com/jeremija/simple-peer.git#expose-transceiver-sender-receiver",
       "dev": true,
       "requires": {
         "debug": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "redux-thunk": "^2.3.0",
     "rimraf": "^3.0.2",
     "screenfull": "^5.0.2",
-    "simple-peer": "git+https://github.com/jeremija/simple-peer.git#transceiver-mid",
+    "simple-peer": "git+https://github.com/jeremija/simple-peer.git#expose-transceiver-sender-receiver",
     "supertest": "^4.0.2",
     "ts-jest": "^25.4.0",
     "ts-node": "^8.10.1",

--- a/src/client/actions/PeerActions.ts
+++ b/src/client/actions/PeerActions.ts
@@ -169,6 +169,9 @@ export function createPeer (options: CreatePeerOptions) {
       config: {
         iceServers,
         enableInsertableStreams: true,
+        // legacy flags for insertable streams
+        forceEncodedVideoInsertableStreams: true,
+        forceEncodedAudioInsertableStreams: true,
       },
       channelName: constants.PEER_DATA_CHANNEL_NAME,
       // trickle: false,

--- a/src/client/actions/PeerActions.ts
+++ b/src/client/actions/PeerActions.ts
@@ -78,12 +78,19 @@ class PeerHandler {
     stream: MediaStream,
     transceiver: RTCRtpTransceiver,
   ) => {
-    insertableStreamsCodec.decrypt(transceiver.receiver)
-
     const { user, dispatch } = this
     const userId = user.id
+    const mid = transceiver.mid!
+
     debug('peer: %s, track: %s, stream: %s, mid: %s',
-          userId, track.id, stream.id, transceiver.mid)
+          userId, track.id, stream.id, mid)
+
+    insertableStreamsCodec.decrypt({
+      receiver: transceiver.receiver,
+      mid,
+      userId,
+    })
+
     // Listen to mute event to know when a track was removed
     // https://github.com/feross/simple-peer/issues/512
     track.onmute = () => {
@@ -99,7 +106,7 @@ class PeerHandler {
         userId, track.id, stream.id)
       dispatch(StreamActions.addTrack({
         streamId: stream.id,
-        mid: transceiver.mid!,
+        mid,
         userId,
         track,
       }))

--- a/src/client/actions/SocketActions.test.ts
+++ b/src/client/actions/SocketActions.test.ts
@@ -144,13 +144,17 @@ describe('SocketActions', () => {
       })
     })
 
+    function tr(mid: string): RTCRtpTransceiver {
+      return { mid } as RTCRtpTransceiver
+    }
+
     describe('track unmute event', () => {
       it('adds a stream to streamStore', () => {
         const stream = new MediaStream()
         const track = new MediaStreamTrack()
         ;(track as any).muted = true
         stream.addTrack(track)
-        peer.emit(constants.PEER_EVENT_TRACK, track, stream, '0')
+        peer.emit(constants.PEER_EVENT_TRACK, track, stream, tr('0'))
 
         expect(track.onunmute).toBeDefined()
         // browsers should call onunmute after 'track' event, when track is
@@ -194,7 +198,7 @@ describe('SocketActions', () => {
         const stream = new MediaStream()
         const track = new MediaStreamTrack()
         stream.addTrack(track)
-        peer.emit(constants.PEER_EVENT_TRACK, track, stream, '0')
+        peer.emit(constants.PEER_EVENT_TRACK, track, stream, tr('0'))
         expect(track.onunmute).toBeDefined()
         track.onunmute!(new Event('unmute'))
         expect(track.onmute).toBeDefined()
@@ -237,7 +241,7 @@ describe('SocketActions', () => {
         const stream = new MediaStream()
         const track = new MediaStreamTrack()
         const mid = '0'
-        peer.emit(constants.PEER_EVENT_TRACK, track, stream, mid)
+        peer.emit(constants.PEER_EVENT_TRACK, track, stream, tr(mid))
         const streams = store.getState().streams.streamsByUserId
         expect(Object.keys(streams)).toEqual([ peerB ])
         const userStreams = streams[peerB].streams

--- a/src/client/actions/SocketActions.ts
+++ b/src/client/actions/SocketActions.ts
@@ -7,6 +7,7 @@ import { ClientSocket } from '../socket'
 import { Dispatch, GetState, Store } from '../store'
 import { removeNickname, setNicknames } from './NicknameActions'
 import { tracksMetadata } from './StreamActions'
+import { insertableStreamsCodec } from '../insertable-streams'
 
 const debug = _debug('peercalls')
 const sdpDebug = _debug('peercalls:sdp')
@@ -53,6 +54,7 @@ class SocketHandler {
     const { dispatch } = this
     debug('metadata', payload)
     dispatch(tracksMetadata(payload))
+    insertableStreamsCodec.setTrackMetadata(payload.metadata)
   }
   handleUsers = ({ initiator, peerIds, nicknames }: SocketEvent['users']) => {
     const { socket, stream, dispatch, getState } = this

--- a/src/client/codec/index.ts
+++ b/src/client/codec/index.ts
@@ -1,6 +1,7 @@
 import { SimpleEmitter } from '../emitter'
 import { TextDecoder, TextEncoder } from '../textcodec'
 import { decodeHeader, encodeHeader, Header, headerSizeBytes } from './header'
+import { WebWorker } from '../webworker'
 
 const maxMessageId = 2**16
 
@@ -39,21 +40,12 @@ export interface EncoderEvents {
 
 type Values<T, K extends keyof T = keyof T> = T[K]
 
-export interface WebWorker<RecvType, SendType> {
-  onmessage: ((e: WorkerMessageEvent<RecvType>) => void) | null
-  postMessage: (data: SendType, transfer: Transferable[]) => void
-}
-
 export interface WorkerPayload {
   messageId: number
   maxMessageSizeBytes: number
   data: Uint8Array
   senderId: string
   senderIdBytes: Uint8Array
-}
-
-export interface WorkerMessageEvent<T> {
-  data: T
 }
 
 export type EncoderWorker = WebWorker<WorkerPayload, Values<EncoderEvents>>

--- a/src/client/components/Toolbar.test.tsx
+++ b/src/client/components/Toolbar.test.tsx
@@ -446,14 +446,15 @@ describe('components/Toolbar track dropdowns', () => {
 
       const password = 'p455w0rd'
       input.value = password
-      TestUtils.Simulate.submit(node.querySelector('.encryption-dialog')!)
+      TestUtils.Simulate.keyUp(input, { key: 'Enter' } as any)
       expect(
         (insertableStreamsCodec.setPassword as jest.Mock).mock.calls,
       ).toEqual([[ password ]])
       expect(button.classList.contains('encryption-enabled')).toBe(true)
 
       input.value = ''
-      TestUtils.Simulate.submit(node.querySelector('.encryption-dialog')!)
+      TestUtils.Simulate.keyUp(input, { key: 'a' } as any) // does nothing
+      TestUtils.Simulate.keyUp(input, { key: 'Enter' } as any)
       expect(
         (insertableStreamsCodec.setPassword as jest.Mock).mock.calls,
       ).toEqual([[ password ], [ '' ]])
@@ -470,7 +471,7 @@ describe('components/Toolbar track dropdowns', () => {
 
       const password = 'p455w0rd'
       input.value = password
-      TestUtils.Simulate.submit(node.querySelector('.encryption-dialog')!)
+      TestUtils.Simulate.keyUp(input, { key: 'Enter' } as any)
       expect(
         (insertableStreamsCodec.setPassword as jest.Mock).mock.calls,
       ).toEqual([[ password ]])

--- a/src/client/components/Toolbar.test.tsx
+++ b/src/client/components/Toolbar.test.tsx
@@ -418,7 +418,7 @@ describe('components/Toolbar track dropdowns', () => {
 
   describe('encryption-dialog', () => {
     beforeEach(() => {
-      (insertableStreamsCodec.setEncryptionKey as jest.Mock).mockClear()
+      (insertableStreamsCodec.setPassword as jest.Mock).mockClear()
     })
 
     it('should toggle dialog', () => {
@@ -448,14 +448,14 @@ describe('components/Toolbar track dropdowns', () => {
       input.value = password
       TestUtils.Simulate.submit(node.querySelector('.encryption-dialog')!)
       expect(
-        (insertableStreamsCodec.setEncryptionKey as jest.Mock).mock.calls,
+        (insertableStreamsCodec.setPassword as jest.Mock).mock.calls,
       ).toEqual([[ password ]])
       expect(button.classList.contains('encryption-enabled')).toBe(true)
 
       input.value = ''
       TestUtils.Simulate.submit(node.querySelector('.encryption-dialog')!)
       expect(
-        (insertableStreamsCodec.setEncryptionKey as jest.Mock).mock.calls,
+        (insertableStreamsCodec.setPassword as jest.Mock).mock.calls,
       ).toEqual([[ password ], [ '' ]])
       expect(button.classList.contains('encryption-enabled')).toBe(false)
     })
@@ -472,7 +472,7 @@ describe('components/Toolbar track dropdowns', () => {
       input.value = password
       TestUtils.Simulate.submit(node.querySelector('.encryption-dialog')!)
       expect(
-        (insertableStreamsCodec.setEncryptionKey as jest.Mock).mock.calls,
+        (insertableStreamsCodec.setPassword as jest.Mock).mock.calls,
       ).toEqual([[ password ]])
 
       expect(button.classList.contains('encryption-enabled')).toBe(false)

--- a/src/client/components/Toolbar.test.tsx
+++ b/src/client/components/Toolbar.test.tsx
@@ -1,3 +1,4 @@
+jest.mock('../insertable-streams')
 jest.mock('simple-peer')
 jest.mock('../window')
 import React from 'react'
@@ -15,6 +16,7 @@ import { middlewares, Store } from '../store'
 import { MediaStream, MediaStreamTrack } from '../window'
 import Toolbar, { ToolbarProps } from './Toolbar'
 import { deferred } from '../deferred'
+import { insertableStreamsCodec } from '../insertable-streams'
 
 interface StreamState {
   cameraStream: LocalStream | null
@@ -412,6 +414,69 @@ describe('components/Toolbar track dropdowns', () => {
 
     })
 
+  })
+
+  describe('encryption-dialog', () => {
+    beforeEach(() => {
+      (insertableStreamsCodec.setEncryptionKey as jest.Mock).mockClear()
+    })
+
+    it('should toggle dialog', () => {
+      let dialog = node.querySelector('.encryption-dialog-visible')
+      expect(dialog).toBeNull()
+
+      const button = node.querySelector('.encryption')!
+      TestUtils.Simulate.click(button)
+
+      dialog = node.querySelector('.encryption-dialog-visible')
+      expect(dialog).not.toBeNull()
+
+      TestUtils.Simulate.click(button)
+
+      dialog = node.querySelector('.encryption-dialog-visible')
+      expect(dialog).toBeNull()
+    })
+
+    it('should set and disable encryption', () => {
+      (insertableStreamsCodec as any).mockSuccess(true)
+
+      const button = node.querySelector('.encryption')!
+      const input = node
+      .querySelector('.encryption-dialog .encryption-key') as HTMLInputElement
+
+      const password = 'p455w0rd'
+      input.value = password
+      TestUtils.Simulate.submit(node.querySelector('.encryption-dialog')!)
+      expect(
+        (insertableStreamsCodec.setEncryptionKey as jest.Mock).mock.calls,
+      ).toEqual([[ password ]])
+      expect(button.classList.contains('encryption-enabled')).toBe(true)
+
+      input.value = ''
+      TestUtils.Simulate.submit(node.querySelector('.encryption-dialog')!)
+      expect(
+        (insertableStreamsCodec.setEncryptionKey as jest.Mock).mock.calls,
+      ).toEqual([[ password ], [ '' ]])
+      expect(button.classList.contains('encryption-enabled')).toBe(false)
+    })
+
+    it('should not succeed when worker is not started', () => {
+      (insertableStreamsCodec as any).mockSuccess(false)
+
+      const button = node.querySelector('.encryption')!
+
+      const input = node
+      .querySelector('.encryption-dialog .encryption-key') as HTMLInputElement
+
+      const password = 'p455w0rd'
+      input.value = password
+      TestUtils.Simulate.submit(node.querySelector('.encryption-dialog')!)
+      expect(
+        (insertableStreamsCodec.setEncryptionKey as jest.Mock).mock.calls,
+      ).toEqual([[ password ]])
+
+      expect(button.classList.contains('encryption-enabled')).toBe(false)
+    })
   })
 
 })

--- a/src/client/components/Toolbar.tsx
+++ b/src/client/components/Toolbar.tsx
@@ -229,7 +229,7 @@ export default class Toolbar extends React.PureComponent<
                 <button onClick={this.setPassword}>Save</button>
               </div>
               <div className='note'>
-                <p><MdWarning /> This functionality is experimental.</p>
+                <p><MdWarning /> Experimental functionality for A/V only.</p>
                 {!this.supportsInsertableStreams && (
                   <p>
                     Your browser does not support Insertable Streams;

--- a/src/client/components/Toolbar.tsx
+++ b/src/client/components/Toolbar.tsx
@@ -113,7 +113,7 @@ export default class Toolbar extends React.PureComponent<
       })
     }
   }
-  setEncryptionKey = (event: React.FormEvent<HTMLFormElement>) => {
+  setPassword = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
 
     const inputElement = this.encryptionKeyInputRef.current!
@@ -121,7 +121,7 @@ export default class Toolbar extends React.PureComponent<
     inputElement.value = ''
 
     const encrypted =
-      insertableStreamsCodec.setEncryptionKey(key) &&
+      insertableStreamsCodec.setPassword(key) &&
       key.length > 0
 
     this.setState({
@@ -213,7 +213,7 @@ export default class Toolbar extends React.PureComponent<
               className={classnames('encryption-dialog', {
                 'encryption-dialog-visible': this.state.encryptionDialogVisible,
               })}
-              onSubmit={this.setEncryptionKey}
+              onSubmit={this.setPassword}
             >
               <div className='encryption-form'>
                 <input

--- a/src/client/components/Toolbar.tsx
+++ b/src/client/components/Toolbar.tsx
@@ -113,9 +113,12 @@ export default class Toolbar extends React.PureComponent<
       })
     }
   }
-  setPassword = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-
+  setPasswordOnEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key == 'Enter') {
+      this.setPassword()
+    }
+  }
+  setPassword = () => {
     const inputElement = this.encryptionKeyInputRef.current!
     const key = inputElement.value
     inputElement.value = ''
@@ -204,27 +207,26 @@ export default class Toolbar extends React.PureComponent<
               className={classnames('encryption', {
                 'encryption-enabled': this.state.encrypted,
               })}
-              on={this.state.encryptionDialogVisible}
+              on={this.state.encryptionDialogVisible || this.state.encrypted}
               icon={encryptionIcon}
               title='Setup Encryption'
             />
-            <form
-              autoComplete='new-password'
+            <div
               className={classnames('encryption-dialog', {
                 'encryption-dialog-visible': this.state.encryptionDialogVisible,
               })}
-              onSubmit={this.setPassword}
             >
               <div className='encryption-form'>
                 <input
-                  autoComplete='new-password'
+                  autoComplete='off'
                   name='encryption-key'
                   className='encryption-key'
                   placeholder='Enter Passphrase'
                   ref={this.encryptionKeyInputRef}
                   type='password'
+                  onKeyUp={this.setPasswordOnEnter}
                 />
-                <input type='submit' value='Save' />
+                <button onClick={this.setPassword}>Save</button>
               </div>
               <div className='note'>
                 <p><MdWarning /> This functionality is experimental.</p>
@@ -236,7 +238,7 @@ export default class Toolbar extends React.PureComponent<
                     enabled in chrome://flags.
                   </p>
                 )} </div>
-            </form>
+            </div>
           </div>
 
         </div>

--- a/src/client/components/ToolbarButton.tsx
+++ b/src/client/components/ToolbarButton.tsx
@@ -21,7 +21,6 @@ export function ToolbarButton(props: ToolbarButtonProps) {
     <a
       className={classnames('button', props.className, { blink, on })}
       onClick={props.onClick}
-      href='#'
     >
       <span className='icon'>
         <Icon />

--- a/src/client/components/Unsupported.tsx
+++ b/src/client/components/Unsupported.tsx
@@ -1,9 +1,7 @@
-import _debug from 'debug'
 import React from 'react'
 import { MdError } from 'react-icons/md'
 import { Message } from './Message'
-
-const debug = _debug('peercalls')
+import { getBrowserFeatures } from '../features'
 
 export class Unsupported extends React.PureComponent {
   supported = isBrowserSupported()
@@ -35,34 +33,12 @@ export class Unsupported extends React.PureComponent {
 }
 
 export function isBrowserSupported() {
-  const media =
-    'mediaDevices' in navigator &&
-    typeof navigator.mediaDevices === 'object' &&
-    typeof navigator.mediaDevices.getUserMedia === 'function' &&
-    typeof navigator.mediaDevices.enumerateDevices === 'function'
-  const mediaStream =
-    typeof MediaStream === 'function' && typeof MediaStreamTrack === 'function'
-  const buffers =
-    typeof TextEncoder === 'function' && typeof TextDecoder === 'function' &&
-    typeof ArrayBuffer === 'function' && typeof Uint8Array === 'function'
-  const webrtc =
-    typeof RTCPeerConnection === 'function' &&
-    typeof RTCPeerConnection.prototype == 'object' &&
-    typeof RTCPeerConnection.prototype.createDataChannel === 'function'
-  const websockets =
-    typeof WebSocket === 'function'
-  const webworkers =
-    typeof Worker === 'function'
+  const features = getBrowserFeatures()
 
-  debug(
-    'browser features supported: %o',
-    { media, mediaStream, buffers, webrtc, websockets, webworkers },
-  )
-
-  return media &&
-    mediaStream &&
-    buffers &&
-    webrtc &&
-    websockets &&
-    webworkers
+  return features.media &&
+    features.mediaStream &&
+    features.buffers &&
+    features.webrtc &&
+    features.websockets &&
+    features.webworkers
 }

--- a/src/client/features.ts
+++ b/src/client/features.ts
@@ -1,0 +1,42 @@
+import _debug from 'debug'
+
+const debug = _debug('peercalls')
+
+export function getBrowserFeatures() {
+  const media =
+    'mediaDevices' in navigator &&
+    typeof navigator.mediaDevices === 'object' &&
+    typeof navigator.mediaDevices.getUserMedia === 'function' &&
+    typeof navigator.mediaDevices.enumerateDevices === 'function'
+  const mediaStream =
+    typeof MediaStream === 'function' && typeof MediaStreamTrack === 'function'
+  const buffers =
+    typeof TextEncoder === 'function' && typeof TextDecoder === 'function' &&
+    typeof ArrayBuffer === 'function' && typeof Uint8Array === 'function'
+  const insertableStreams =
+    typeof RTCRtpSender === 'function' &&
+    typeof RTCRtpSender.prototype.createEncodedStreams === 'function'
+  const webrtc =
+    typeof RTCPeerConnection === 'function' &&
+    typeof RTCPeerConnection.prototype == 'object' &&
+    typeof RTCPeerConnection.prototype.createDataChannel === 'function'
+  const websockets =
+    typeof WebSocket === 'function'
+  const webworkers =
+    typeof Worker === 'function'
+
+
+  const features = {
+    media,
+    mediaStream,
+    buffers,
+    insertableStreams,
+    webrtc,
+    websockets,
+    webworkers,
+  }
+
+  debug('browser features supported: %o', features)
+
+  return features
+}

--- a/src/client/insertable-streams/__mocks__/index.ts
+++ b/src/client/insertable-streams/__mocks__/index.ts
@@ -5,7 +5,7 @@ export const insertableStreamsCodec = {
     success = ok
   },
 
-  setEncryptionKey: jest.fn().mockImplementation(() => {
+  setPassword: jest.fn().mockImplementation(() => {
     return success
   }),
 

--- a/src/client/insertable-streams/__mocks__/index.ts
+++ b/src/client/insertable-streams/__mocks__/index.ts
@@ -1,0 +1,19 @@
+let success = false
+
+export const insertableStreamsCodec = {
+  mockSuccess(ok: boolean) {
+    success = ok
+  },
+
+  setEncryptionKey: jest.fn().mockImplementation(() => {
+    return success
+  }),
+
+  encrypt: jest.fn().mockImplementation(() => {
+    return success
+  }),
+
+  decrypt: jest.fn().mockImplementation(() => {
+    return success
+  }),
+}

--- a/src/client/insertable-streams/index.ts
+++ b/src/client/insertable-streams/index.ts
@@ -136,7 +136,7 @@ const workerFunc = () => (self: EncryptionWorker) => {
       {
         name: 'PBKDF2',
         salt,
-        iterations: 1000, // FIXME
+        iterations: 150000,
         hash: 'SHA-1',
       },
       passwordKey,

--- a/src/client/insertable-streams/index.ts
+++ b/src/client/insertable-streams/index.ts
@@ -152,7 +152,7 @@ export class InsertableStreamsCodec {
     }
   }
 
-  setEncryptionKey(encryptionKey: string) {
+  setEncryptionKey(encryptionKey: string): boolean{
     const message: EncryptionKeyEvent = {
       type: 'encryption-key',
       encryptionKey: encryptionKey,
@@ -160,7 +160,10 @@ export class InsertableStreamsCodec {
 
     if (this.worker) {
       this.worker.postMessage(message)
+      return true
     }
+
+    return false
   }
 
   encrypt(sender: RTCRtpSender): boolean {

--- a/src/client/insertable-streams/index.ts
+++ b/src/client/insertable-streams/index.ts
@@ -331,7 +331,7 @@ const workerFunc = () => (self: EncryptionWorker) => {
       })
     })
     .catch(err => {
-      // decryption will throw errors
+      // Decryption with invalid key will throw errors.
     })
     .finally(() => {
       // TODO perhaps it would be wiser not to show unencrypted streams when

--- a/src/client/insertable-streams/index.ts
+++ b/src/client/insertable-streams/index.ts
@@ -1,0 +1,209 @@
+import { WebWorker } from '../webworker'
+import _debug from 'debug'
+
+const debug = _debug('peercalls')
+
+export interface StreamEvent {
+  type: 'encrypt' | 'decrypt'
+  readableStream: ReadableStream<RTCEncodedFrame>
+  writableStream: WritableStream<RTCEncodedFrame>
+}
+
+export interface EncryptionKeyEvent {
+  type: 'encryption-key'
+  encryptionKey: string
+}
+
+export type PostMessageEvent = StreamEvent | EncryptionKeyEvent
+
+export type EncryptionWorker = WebWorker<PostMessageEvent, void>
+
+const workerFunc = () => (self: EncryptionWorker) => {
+  let encryptionKey = ''
+
+  function encrypt<T extends RTCEncodedFrame>(
+    frame: T,
+    controller: TransformStreamDefaultController<T>,
+  ) {
+    if (encryptionKey) {
+      const view = new DataView(frame.data)
+      // Any length that is needed can be used for the new buffer.
+      const newData = new ArrayBuffer(frame.data.byteLength + 5)
+      const newView = new DataView(newData)
+
+      // const cryptoOffset = useCryptoOffset
+      // ? frameTypeToCryptoOffset[encodedFrame.type]
+      // : 0
+      const cryptoOffset = 0
+
+      for (let i = 0; i < cryptoOffset && i < frame.data.byteLength; i++) {
+        newView.setInt8(i, view.getInt8(i))
+      }
+
+      // This is a bitwise xor of the key with the payload. This is not strong
+      // encryption, just a demo.
+      for (let i = cryptoOffset; i < frame.data.byteLength; ++i) {
+        const keyByte = encryptionKey.charCodeAt(i % encryptionKey.length)
+        newView.setInt8(i, view.getInt8(i) ^ keyByte)
+      }
+
+      // Append checksum
+      newView.setUint32(frame.data.byteLength, 0xDEADBEEF)
+
+      frame.data = newData
+    }
+    controller.enqueue(frame)
+  }
+
+  function decrypt<T extends RTCEncodedFrame>(
+    frame: T,
+    controller: TransformStreamDefaultController<T>,
+  ) {
+    const view = new DataView(frame.data)
+    const checksum = frame.data.byteLength > 4
+      ? view.getUint32(frame.data.byteLength - 4)
+      : false
+
+    if (encryptionKey) {
+      if (checksum !== 0xDEADBEEF) {
+        console.log('Corrupted frame received checksum',  checksum.toString(16))
+        // This can happen when the key is set and there is an unencrypted
+        // frame in-flight.
+        return
+      }
+
+      const newData = new ArrayBuffer(frame.data.byteLength - 4)
+      const newView = new DataView(newData)
+
+      // const cryptoOffset = useCryptoOffset
+      // ? frameTypeToCryptoOffset[encodedFrame.type]
+      // : 0
+      const cryptoOffset = 0
+
+      for (let i = 0; i < cryptoOffset; ++i) {
+        newView.setInt8(i, view.getInt8(i))
+      }
+
+      for (let i = cryptoOffset; i < frame.data.byteLength - 5; ++i) {
+        const keyByte = encryptionKey.charCodeAt(i % encryptionKey.length)
+        newView.setInt8(i, view.getInt8(i) ^ keyByte)
+      }
+      frame.data = newData
+    }
+    controller.enqueue(frame)
+  }
+
+  self.onmessage = event => {
+    const message = event.data
+    switch (message.type) {
+      case 'encryption-key':
+        encryptionKey = message.encryptionKey
+        break
+      case 'encrypt':
+        message.readableStream
+        .pipeThrough(new TransformStream({
+          transform: encrypt,
+        }))
+        .pipeTo(message.writableStream)
+        break
+      case 'decrypt':
+        message.readableStream
+        .pipeThrough(new TransformStream({
+          transform: decrypt,
+        }))
+        .pipeTo(message.writableStream)
+    }
+  }
+}
+
+export class InsertableStreamsCodec {
+  protected worker?: Worker
+  protected readonly workerBlobURL?: string
+
+  constructor() {
+    if (!(
+      typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function'
+    )) {
+      return
+    }
+    this.workerBlobURL = URL.createObjectURL(
+      new Blob(
+        ['(', workerFunc.toString(), ')()(self)'],
+        {type: 'application/javascript'},
+      ),
+    )
+
+    if (
+      !(
+        typeof RTCRtpSender !== 'undefined' &&
+        typeof RTCRtpSender.prototype.createEncodedStreams === 'function' &&
+        typeof RTCRtpReceiver !== 'undefined' &&
+        typeof RTCRtpReceiver.prototype.createEncodedStreams === 'function'
+      )
+    ) {
+      debug('Environment does not support insertable streams')
+      return
+    }
+
+    try {
+      this.worker = new Worker(this.workerBlobURL)
+    } catch (err) {
+      debug('Error creating insertable streams worker: %s', err)
+    }
+  }
+
+  setEncryptionKey(encryptionKey: string) {
+    const message: EncryptionKeyEvent = {
+      type: 'encryption-key',
+      encryptionKey: encryptionKey,
+    }
+
+    if (this.worker) {
+      this.worker.postMessage(message)
+    }
+  }
+
+  encrypt(sender: RTCRtpSender): boolean {
+    if (!this.worker) {
+      return false
+    }
+
+    const streams = sender.createEncodedStreams!()
+
+    const message: StreamEvent = {
+      type: 'encrypt',
+      readableStream: streams.readableStream,
+      writableStream: streams.writableStream,
+    }
+
+    this.worker.postMessage(message, [
+      streams.readableStream,
+      streams.writableStream,
+    ] as unknown as Transferable[])
+
+    return true
+  }
+
+  decrypt(receiver: RTCRtpReceiver): boolean{
+    if (!this.worker) {
+      return false
+    }
+
+    const streams = receiver.createEncodedStreams!()
+
+    const message: StreamEvent = {
+      type: 'decrypt',
+      readableStream: streams.readableStream,
+      writableStream: streams.writableStream,
+    }
+
+    this.worker.postMessage(message, [
+      streams.readableStream,
+      streams.writableStream,
+    ] as unknown as Transferable[])
+
+    return true
+  }
+}
+
+export const insertableStreamsCodec = new InsertableStreamsCodec()

--- a/src/client/reducers/peers.ts
+++ b/src/client/reducers/peers.ts
@@ -7,6 +7,7 @@ import * as constants from '../constants'
 import { MediaStreamAction, MediaTrackAction, MediaTrackEnableAction, MediaKind } from '../actions/MediaActions'
 import { RemoveLocalStreamAction, StreamType } from '../actions/StreamActions'
 import { HangUpAction } from '../actions/CallActions'
+import { insertableStreamsCodec } from '../insertable-streams'
 
 const debug = _debug('peercalls')
 
@@ -66,7 +67,8 @@ function handleLocalMediaStream(
         'Add track to peer, id: %s, kind: %s, label: %s',
         track.id, track.kind, track.label,
       )
-      peer.addTrack(track, stream)
+      const sender = peer.addTrack(track, stream)
+      insertableStreamsCodec.encrypt(sender)
     })
   })
   localStreams[streamType] = action.payload.stream
@@ -124,7 +126,8 @@ export function handleLocalMediaTrack(
 
   if (newTrack) {
     forEach(state, peer => {
-      peer.addTrack(newTrack, localStream)
+      const sender = peer.addTrack(newTrack, localStream)
+      insertableStreamsCodec.encrypt(sender)
     })
     localStream.addTrack(newTrack)
     return state

--- a/src/client/webworker/index.ts
+++ b/src/client/webworker/index.ts
@@ -1,0 +1,9 @@
+export interface WorkerMessageEvent<T> {
+  data: T
+}
+
+export interface WebWorker<RecvType, SendType> {
+  onmessage: ((e: WorkerMessageEvent<RecvType>) => void) | null
+  postMessage: (data: SendType, transfer: Transferable[]) => void
+}
+

--- a/src/sass/_toolbar.sass
+++ b/src/sass/_toolbar.sass
@@ -8,6 +8,38 @@
     visibility: hidden
     transition: opacity 200ms ease-in 0ms, visibility 0ms ease-in 200ms
 
+  .encryption-dialog
+    opacity: 0
+    visibility: hidden
+    transition: opacity 200ms ease-in 0ms, visibility 0ms ease-in 200ms
+    position: absolute
+    white-space: nowrap
+
+    // TODO fix this
+    width: 300px
+    left: 100%
+    left: calc(100% - 0.5rem)
+    bottom: 1rem
+
+    input
+      padding: 15px 10px
+      border-radius: 4px
+      border-bottom: 2px solid darken(#fff, 10%)
+      color: black
+      background-color: white
+      transition: border-radius 100ms ease-in, border-color 100ms ease-in
+
+    input[type=password]
+      margin-right: 0.5rem
+
+    input[type=submit]
+      @include button($color-primary, $color-warning)
+
+    &.encryption-dialog-visible
+      visibility: visible
+      opacity: 1
+      transition: opacity 200ms ease-in 0ms, visibility 0ms ease-in 0ms
+
   position: absolute
   display: flex
   flex-direction: column

--- a/src/sass/_toolbar.sass
+++ b/src/sass/_toolbar.sass
@@ -8,22 +8,32 @@
     visibility: hidden
     transition: opacity 200ms ease-in 0ms, visibility 0ms ease-in 200ms
 
+  .encryption-wrapper
+    position: relative
+
   .encryption-dialog
     opacity: 0
     visibility: hidden
     transition: opacity 200ms ease-in 0ms, visibility 0ms ease-in 200ms
     position: absolute
-    white-space: nowrap
+
+    &.encryption-dialog-visible
+      visibility: visible
+      opacity: 1
+      transition: opacity 200ms ease-in 0ms, visibility 0ms ease-in 0ms
+
+    .encryption-form
+      white-space: nowrap
 
     // TODO fix this
     width: 300px
     left: 100%
-    left: calc(100% - 0.5rem)
-    bottom: 1rem
+    top: 0.5rem
 
     input
       padding: 15px 10px
       border-radius: 4px
+      border-color: transparent
       border-bottom: 2px solid darken(#fff, 10%)
       color: black
       background-color: white
@@ -35,10 +45,11 @@
     input[type=submit]
       @include button($color-primary, $color-warning)
 
-    &.encryption-dialog-visible
-      visibility: visible
-      opacity: 1
-      transition: opacity 200ms ease-in 0ms, visibility 0ms ease-in 0ms
+    .note
+      color: $color-warning
+      font-size: 0.8rem
+      text-shadow: 0 0 2px black
+
 
   position: absolute
   display: flex

--- a/src/sass/_toolbar.sass
+++ b/src/sass/_toolbar.sass
@@ -12,6 +12,10 @@
     position: relative
 
   .encryption-dialog
+    background: rgba(darken($color-bg, 5%), 0.8)
+    border: 1px solid darken($color-bg, 10%)
+    padding: 0.5rem;
+    border-radius: 4px
     opacity: 0
     visibility: hidden
     transition: opacity 200ms ease-in 0ms, visibility 0ms ease-in 200ms
@@ -25,16 +29,16 @@
     .encryption-form
       white-space: nowrap
 
-    width: 300px
+    // width: 300px
     left: 100%
-    top: 0.5rem
-    top: calc(0.5rem + 2px)
+    top: 2px
 
     input, button
       padding: 15px 10px
       border-radius: 4px
 
     input
+      min-width: 200px
       border: none
       border-color: transparent
       border-bottom: 2px solid darken(#fff, 10%)
@@ -53,6 +57,8 @@
       font-size: 0.8rem
       text-shadow: 0 0 2px black
 
+      p:last-child
+        margin-bottom: 0
 
   position: absolute
   display: flex

--- a/src/sass/_toolbar.sass
+++ b/src/sass/_toolbar.sass
@@ -25,14 +25,17 @@
     .encryption-form
       white-space: nowrap
 
-    // TODO fix this
     width: 300px
     left: 100%
     top: 0.5rem
+    top: calc(0.5rem + 2px)
 
-    input
+    input, button
       padding: 15px 10px
       border-radius: 4px
+
+    input
+      border: none
       border-color: transparent
       border-bottom: 2px solid darken(#fff, 10%)
       color: black
@@ -42,7 +45,7 @@
     input[type=password]
       margin-right: 0.5rem
 
-    input[type=submit]
+    input[type=submit], button
       @include button($color-primary, $color-warning)
 
     .note

--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -50,7 +50,7 @@ body.call
   box-sizing: border-box
   color: $color-fg
   // font-size: 1.2rem
-  text-shadow: 0 0 0.35rem rgba(0, 0, 0, 0.6)r
+  text-shadow: 0 0 0.35rem rgba(0, 0, 0, 0.6)
 
 @mixin button($color-fg, $color-bg)
   @include button-style($color-fg, $color-bg)

--- a/types/insertable-streams.d.ts
+++ b/types/insertable-streams.d.ts
@@ -1,0 +1,58 @@
+/// <reference no-default-lib="true"/>
+
+// These type definitions are taken from
+// https://w3c.github.io/webrtc-insertable-streams/
+
+interface RTCConfiguration {
+  encodedInsertableStreams?: bool
+}
+
+interface RTCRtpSender {
+  createEncodedStreams?: () => RTCInsertableStreams
+}
+
+interface RTCRtpReceiver {
+  createEncodedStreams?: () => RTCInsertableStreams
+}
+
+interface RTCInsertableStreams {
+  readableStream: ReadableStream<RTCEncodedFrame>
+  writableStream: WritableStream<RTCEncodedFrame>
+}
+
+// New enum for video frame types. Will eventually re-use the equivalent
+// defined by WebCodecs.
+type RTCEncodedVideoFrameType = 'empty' | 'key' | 'delta'
+
+type RTCEncodedFrame = RTCEncodedVideoFrame | RTCEncodedAudioFrame
+
+interface RTCEncodedVideoFrameMetadata {
+  frameId: number
+  dependencies: number[]
+  width: number
+  height: number
+  spatialIndex: number
+  temporalIndex: number
+  synchronizationSource: number
+  contributingSources: number[]
+}
+
+// New interfaces to define encoded video and audio frames. Will eventually
+// re-use or extend the equivalent defined in WebCodecs.
+interface RTCEncodedVideoFrame {
+  readonly type: RTCEncodedVideoFrameType
+  readonly timestamp: number
+  data: ArrayBuffer
+  getMetadata(): RTCEncodedVideoFrameMetadata
+}
+
+interface RTCEncodedAudioFrameMetadata {
+    synchronizationSource: number
+    contributingSources: number[]
+}
+
+interface RTCEncodedAudioFrame {
+  readonly timestamp: number
+  data: ArrayBuffer
+  getMetadata(): RTCEncodedAudioFrameMetadata
+}

--- a/types/simple-peer.d.ts
+++ b/types/simple-peer.d.ts
@@ -1,0 +1,9 @@
+import { Instance } from 'simple-peer'
+
+declare module 'simple-peer' {
+  interface Instance {
+    // addTrack is an extended function in jeremija/simple-peer fork that
+    // returns a sender.
+    addTrack(track: MediaStreamTrack, stream: MediaStream): RTCRtpSender
+  }
+}


### PR DESCRIPTION
- [x] Add support for encryption and decryption
- [x] Add support for using custom passphrase
- [x] Add password input dialog
- [x] Add a warning when using unsupported browsers (currently only Chrome supports insertable streams 😞 )
- [x] Use WebCrypto to derive `PBKDF2` and `AES-GCM` encryption keys
- [x] Fix an issue when a remote stream cannot be decrypted on remote user reconnect.

Closes #141

# How does it work?

Currently only Chrome is supported, and the flag `Experimental Web Platform Features` needs to be enabledenabled in chrome://flags.

The passphrase is used to derive a `PBKDF2` key, which is then used to create a 256-bit `AES-GCM` key. The salt is constructed from the full call URL and the userID (UUID) received from the server. This is to avoid sending the key information via SFU to other participants.

Each participant generates their own key for encrypting their own streams, as well as keys for decrypting remote streams from all other participants.

To enable encryption, users can use the new toolbar button with a lock icon:

<img width="351" alt="image" src="https://user-images.githubusercontent.com/1489493/90310010-b4ca6580-deed-11ea-92fd-4d829ea0f870.png">

This can be set up before joining the call.

A warning will be shown for unsupported browsers:

<img width="347" alt="image" src="https://user-images.githubusercontent.com/1489493/90309995-9d8b7800-deed-11ea-9ad6-3d7674bc0541.png">

An example with two peers using different passwords:

![image](https://user-images.githubusercontent.com/1489493/90310069-5782e400-deee-11ea-90ea-4e36ae633264.png)
