### PR TITLE
Reduce Docker image size, improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:12-alpine as frontend
 
 # Add dependency instructions and fetch node_modules
 COPY package.json package-lock.json /src/
-wORKDIR /src
+WORKDIR /src
 
 RUN set -ex \
  && apk add --no-cache \
@@ -27,7 +27,7 @@ RUN set -ex \
 
 # Add dependencies into mod cache
 COPY go.mod go.sum /src/
-wORKDIR /src
+WORKDIR /src
 
 RUN set -ex \
  && go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,41 @@
-FROM node:12-alpine
-WORKDIR /app
-RUN apk add --no-cache git
-RUN chown node:node /app
-COPY package.json .
-USER node
-RUN npm install
-COPY webpack* tsconfig.json ./
-COPY src src
-RUN npm run build
+FROM node:12-alpine as frontend
 
-FROM golang:1.14-buster
-WORKDIR /app
-RUN chown nobody /app
-RUN go get -u github.com/gobuffalo/packr/packr
-COPY go.mod go.sum ./
-RUN go mod download
-COPY --from=0 /app/build build
-COPY .git .git
-COPY res res
-COPY server server
-COPY main.go .
-RUN packr build -ldflags "-X main.gitDescribe=$(git describe --always --tags)" -o peer-calls main.go
+COPY ./ /src/
+wORKDIR /src
 
-FROM debian:buster-slim
-WORKDIR /app
-COPY --from=1 /app/peer-calls .
-USER nobody
-EXPOSE 3000
+RUN set -ex \
+ && apk add --no-cache \
+      git \
+ && npm ci \
+ && npm run build
+
+
+FROM golang:alpine as server
+
+ENV CGO_ENABLED=0
+
+RUN set -ex \
+ && apk add --no-cache \
+      git \
+ && GOPATH=/usr/local go get -u github.com/gobuffalo/packr/packr
+
+COPY                  ./          /src/
+COPY --from=frontend  /src/build/ /src/build/
+wORKDIR /src
+
+RUN set -ex \
+ && packr build \
+      -ldflags "-X main.gitDescribe=$(git describe --always --tags --dirty)" \
+      -mod=readonly \
+      -o peer-calls
+
+
+FROM scratch
+
+COPY --from=server /src/peer-calls /usr/local/bin/
+
+EXPOSE 3000/tcp
 STOPSIGNAL SIGINT
-ENTRYPOINT ["./peer-calls"]
+USER nobody
+
+ENTRYPOINT ["/usr/local/bin/peer-calls"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,5 @@ COPY --from=server /src/peer-calls /usr/local/bin/
 
 EXPOSE 3000/tcp
 STOPSIGNAL SIGINT
-USER nobody
 
 ENTRYPOINT ["/usr/local/bin/peer-calls"]


### PR DESCRIPTION
- Uses `npm ci` to use exactly the dependency versions from `package-lock.json` instead of changing them
- Makes the `Dockerfile` a little more readable (and simplifies the build process)
- Reduces the size of the Docker image a lot by cutting out Debian (which also reduces the attack surface on the image to just the built binary instead of many Debian packages)

```console
# docker build -t registry.local/peer-calls .
[...]
# docker images
REPOSITORY                      TAG                 IMAGE ID            CREATED              SIZE
registry.local/peer-calls       latest              6baed08ff661        46 seconds ago       22.7MB
```