### PR TITLE
Group audio/video devices separately

### DIFF
--- a/src/client/actions/MediaActions.ts
+++ b/src/client/actions/MediaActions.ts
@@ -1,9 +1,8 @@
 import _debug from 'debug'
 import { AsyncAction, makeAction } from '../async'
-import { DEVICE_DISABLED_ID, MEDIA_ENUMERATE, MEDIA_STREAM, MEDIA_TRACK, MEDIA_TRACK_ENABLE, MEDIA_SIZE_CONSTRAINT, MEDIA_DEVICE_ID, MEDIA_DEVICE_TOGGLE, DEVICE_DEFAULT_ID } from '../constants'
-import { AddLocalStreamPayload, StreamTypeCamera, StreamTypeDesktop, StreamType } from './StreamActions'
+import { DEVICE_DEFAULT_ID, DEVICE_DISABLED_ID, MEDIA_DEVICE_ID, MEDIA_DEVICE_TOGGLE, MEDIA_ENUMERATE, MEDIA_SIZE_CONSTRAINT, MEDIA_STREAM, MEDIA_TRACK, MEDIA_TRACK_ENABLE } from '../constants'
 import { MediaStream } from '../window'
-import uniqBy from 'lodash/uniqBy'
+import { AddLocalStreamPayload, StreamType, StreamTypeCamera, StreamTypeDesktop } from './StreamActions'
 
 const debug = _debug('peercalls')
 
@@ -41,15 +40,13 @@ export const enumerateDevices = makeAction(MEDIA_ENUMERATE, async () => {
   }
 
   const mappedDevices = devices
-  .filter(
-    device => device.kind === 'audioinput' || device.kind === 'videoinput')
   .map(device => ({
     id: device.deviceId,
     type: device.kind,
     name: device.label,
   }) as MediaDevice)
 
-  return uniqBy(mappedDevices, item => item.id)
+  return mappedDevices
 })
 
 declare global {

--- a/src/client/components/DeviceDropdown.tsx
+++ b/src/client/components/DeviceDropdown.tsx
@@ -36,11 +36,6 @@ const labels = {
   video: 'Video',
 }
 
-const kindToDeviceType = {
-  audio: 'audioinput',
-  video: 'videoinput',
-}
-
 const qualityLow: SizeConstraint  = {
   width: 320,
   height: 240,
@@ -149,10 +144,7 @@ extends React.PureComponent<DeviceDropdownProps, DeviceDropdownState> {
   render() {
     const { mediaConstraint } = this.props
 
-    const deviceType = kindToDeviceType[this.props.kind]
-
     const devices = this.props.devices
-    .filter(device => device.type === deviceType)
 
     const { height } = mediaConstraint.constraints
 
@@ -295,7 +287,7 @@ function mapVideoStateToProps(state: State) {
     offIcon: MdVideocam,
     title: 'Camera',
     kind: 'video' as 'video',
-    devices: state.media.devices,
+    devices: state.media.devices.video,
     mediaConstraint: state.media.video,
     cameraStream,
   }
@@ -310,7 +302,7 @@ function mapAudioStateToProps(state: State) {
     offIcon: MdMic,
     title: 'Microphone',
     kind: 'audio' as 'audio',
-    devices: state.media.devices,
+    devices: state.media.devices.audio,
     mediaConstraint: state.media.audio,
     cameraStream,
   }

--- a/src/client/components/Media.tsx
+++ b/src/client/components/Media.tsx
@@ -163,7 +163,7 @@ extends React.PureComponent<MediaProps, MediaComponentState> {
             autoComplete='off'
           >
             <Options
-              devices={props.devices}
+              devices={props.devices.video}
               default={DEVICE_DEFAULT_ID}
               type='videoinput'
             />
@@ -178,7 +178,7 @@ extends React.PureComponent<MediaProps, MediaComponentState> {
             autoComplete='off'
           >
             <Options
-              devices={props.devices}
+              devices={props.devices.audio}
               default={DEVICE_DEFAULT_ID}
               type='audioinput'
             />
@@ -263,7 +263,6 @@ function Options(props: OptionsProps) {
       <option value={DEVICE_DEFAULT_ID}>Default {label}</option>
       {
         props.devices
-        .filter(device => device.type === props.type)
         .map(device =>
           <option
             key={device.id}

--- a/src/client/reducers/media.test.ts
+++ b/src/client/reducers/media.test.ts
@@ -49,6 +49,14 @@ describe('media', () => {
           label: 'Audio Input',
           toJSON,
         }, {
+          // duplicate device should be filtered out.
+          // sometimes cameras have two devices with different label (e.g. IR)
+          deviceId: 'abcdef2',
+          groupId: 'group1',
+          kind: 'audioinput',
+          label: 'Audio Input',
+          toJSON,
+        }, {
           deviceId: 'abcdef3',
           groupId: 'group2',
           kind: 'audiooutput',
@@ -61,15 +69,18 @@ describe('media', () => {
 
     it('retrieves a list of audioinput/videoinput devices', async () => {
       await store.dispatch(MediaActions.enumerateDevices())
-      expect(store.getState().media.devices).toEqual([{
-        id: 'abcdef1',
-        name: 'Video Input',
-        type: 'videoinput',
-      }, {
-        id: 'abcdef2',
-        name: 'Audio Input',
-        type: 'audioinput',
-      }])
+      expect(store.getState().media.devices).toEqual({
+        audio: [{
+          id: 'abcdef2',
+          name: 'Audio Input',
+          type: 'audioinput',
+        }],
+        video: [{
+          id: 'abcdef1',
+          name: 'Video Input',
+          type: 'videoinput',
+        }],
+      })
     })
 
     it('handles errors', async () => {
@@ -79,7 +90,7 @@ describe('media', () => {
       } catch (err) {
         // do nothing
       }
-      expect(store.getState().media.devices).toEqual([])
+      expect(store.getState().media.devices).toEqual({ audio: [], video: [] })
       expect(store.getState().media.error).toBeTruthy()
     })
   })


### PR DESCRIPTION
Index devices in `reducers/media.ts`. This will remove the requirement for each UI component to filter audio or video devices separately. Also keep only unique device IDs to keep React from complaining - sometimes cameras have the same device ID for IR and WebCam, and the video feed is the same no matter which one is selected (because they have the same device ID)