### PR TITLE
reset screenshare state when stream terminated via browser toolbar

### DIFF
--- a/src/client/components/ShareDesktopDropdown.tsx
+++ b/src/client/components/ShareDesktopDropdown.tsx
@@ -96,6 +96,10 @@ React.PureComponent<ShareDesktopDropdownProps, ShareDesktopDropdownState> {
         t.onended = () => {
           activeTracks--
           if (activeTracks === 0) {
+            this.setState({
+              shareConfig: false,
+            })
+
             this.props.onRemoveLocalStream(payload.stream, payload.type)
           }
         }


### PR DESCRIPTION
This should fix the last remaining bit of #191 where toolbar button isn't reset to its default state when stream is terminated by browser's "stop streaming" button