### PR TITLE
disable screen sharing on mobile platforms

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,8 @@ module.exports = {
     'js',
     'jsx',
   ],
-  setupFiles: ['<rootDir>/jest.setup.js'],
+  setupFiles: [
+    '<rootDir>/jest.setup.js',
+    'jest-useragent-mock',
+  ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8639,6 +8639,12 @@
         }
       }
     },
+    "jest-useragent-mock": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jest-useragent-mock/-/jest-useragent-mock-0.1.1.tgz",
+      "integrity": "sha512-QmgydWl2ITj0xuWQfxj+TmXN0GT2XXxfNhsPzfhNVecjX7VnqLmCKXtr+J5QjT01DDp4+oWIGACdywO6XJlkRg==",
+      "dev": true
+    },
     "jest-util": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-react": "^7.23.2",
     "fastestsmallesttextencoderdecoder": "^1.0.22",
     "jest": "^26.6.3",
+    "jest-useragent-mock": "^0.1.1",
     "lodash": "^4.17.21",
     "process": "^0.11.10",
     "react": "^17.0.2",

--- a/src/client/components/ShareDesktopDropdown.tsx
+++ b/src/client/components/ShareDesktopDropdown.tsx
@@ -41,19 +41,32 @@ export interface ShareDesktopDropdownState {
   shareConfig: ShareDesktopConfig | false
   rejectedShare: boolean
   popupContent: ReactFragment | null
+  isDisabled: boolean
 }
 
 export class ShareDesktopDropdown extends
 React.PureComponent<ShareDesktopDropdownProps, ShareDesktopDropdownState> {
-  state: ShareDesktopDropdownState = {
-    open: false,
-    shareConfig: false,
-    rejectedShare: false,
-    popupContent: null,
+
+  constructor(props: ShareDesktopDropdownProps) {
+    super(props)
+    // mobile devices don't support screen sharing
+    const isMobile = /Android|iPhone|iPad|iPod/i.test(
+      window.navigator.userAgent,
+    )
+    this.state = {
+      open: false,
+      shareConfig: false,
+      rejectedShare: false,
+      popupContent: null,
+      isDisabled: isMobile,
+    }
   }
+
   toggleOpen = (e: React.SyntheticEvent) => {
     e.stopPropagation()
-    this.setOpen(!this.state.open)
+    if (!this.state.isDisabled) {
+      this.setOpen(!this.state.open)
+    }
   }
   close = () => {
     this.setOpen(false)
@@ -106,7 +119,7 @@ React.PureComponent<ShareDesktopDropdownProps, ShareDesktopDropdownState> {
       })
     })
     .catch(() => {
-      const browser = navigator.userAgent.toLowerCase()
+      const browser = window.navigator.userAgent.toLowerCase()
       if (browser.indexOf('firefox') > -1) {
         this.handleFirefoxRejection()
       }
@@ -140,7 +153,7 @@ React.PureComponent<ShareDesktopDropdownProps, ShareDesktopDropdownState> {
   }
 
   render() {
-    const { shareConfig, popupContent } = this.state
+    const { shareConfig, popupContent, isDisabled } = this.state
 
     const classNames = classnames(
       'stream-desktop-menu dropdown-list dropdown-center',
@@ -162,7 +175,7 @@ React.PureComponent<ShareDesktopDropdownProps, ShareDesktopDropdownState> {
 
         <div className='dropdown'>
           <ToolbarButton
-            className={this.props.className}
+            className={this.props.className + (isDisabled ? ' disabled' : '')}
             icon={this.props.icon}
             offIcon={this.props.offIcon}
             on={shareConfig !== false}

--- a/src/sass/_toolbar.sass
+++ b/src/sass/_toolbar.sass
@@ -155,7 +155,15 @@
     &.on .icon
       background: lighten(#407cf7, 10%)
 
+    &.disabled
+      cursor: not-allowed
 
+      .icon
+        cursor: not-allowed
+        box-shadow: none
+        color: rgba(200, 150, 150, 0.5)
+        border: 1px solid rgba(200, 150, 150, 0.5)
+        background: inherit
 
   @media (max-width: 350px)
     &.toolbar-call


### PR DESCRIPTION
fix for #206 

The support of screen sharing cant be detected, so it's done via user agent detection.

Disabled icon looks following way:

![](http://io.vanyli.net/disabled-screenshare.png)