### PR TITLE
Fix media picker before joining the call

### DIFF
--- a/src/client/__mocks__/window.ts
+++ b/src/client/__mocks__/window.ts
@@ -111,3 +111,9 @@ export class AudioWorkletNode {
 
   constructor(readonly context: BaseAudioContext, readonly name: string) {}
 }
+
+export const blackTrack = new MediaStreamTrack()
+
+export const createBlackVideoTrack = (width: number, height: number) => {
+  return blackTrack
+}

--- a/src/client/components/Media.test.tsx
+++ b/src/client/components/Media.test.tsx
@@ -5,13 +5,12 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import TestUtils from 'react-dom/test-utils'
 import { Provider } from 'react-redux'
-import { createStore, Store } from '../store'
-import { Media } from './Media'
-import { MEDIA_ENUMERATE, ME, DIAL, DIAL_STATE_IN_CALL, DIAL_STATE_HUNG_UP } from '../constants'
 import { dial } from '../actions/CallActions'
-import { MediaStream } from '../window'
-
+import { DEVICE_DEFAULT_ID, DEVICE_DISABLED_ID, DIAL, DIAL_STATE_HUNG_UP, DIAL_STATE_IN_CALL, ME, MEDIA_ENUMERATE } from '../constants'
 import { MediaConstraint } from '../reducers/media'
+import { createStore, Store } from '../store'
+import { MediaStream } from '../window'
+import { Media } from './Media'
 
 describe('Media', () => {
 
@@ -27,8 +26,8 @@ describe('Media', () => {
         type: 'audioinput',
       }, {
         id: '456',
-        label: 'Video Input',
-        name: 'videoinput',
+        name: 'Video Input',
+        type: 'videoinput',
       }],
     })
   })
@@ -128,6 +127,42 @@ describe('Media', () => {
       expect(store.getState().media.dialState).toBe(DIAL_STATE_HUNG_UP)
       const nickname = store.getState().nicknames[ME]
       expect((dial as jest.Mock).mock.calls).toEqual([[ { nickname } ]])
+    })
+  })
+
+  describe('options', () => {
+    it('should populate audio options', async () => {
+      const node = await render()
+      const options = Array.from(
+        node.querySelectorAll('select[name=audio-input] option')!,
+      )
+      expect(options.map(o => o.getAttribute('value'))).toEqual([
+        DEVICE_DISABLED_ID,
+        DEVICE_DEFAULT_ID,
+        '123',
+      ])
+      expect(options.map(o => o.textContent!.trim())).toEqual([
+        'No Audio',
+        'Default Audio',
+        'Audio Input',
+      ])
+    })
+
+    it('should populate video options', async () => {
+      const node = await render()
+      const options = Array.from(
+        node.querySelectorAll('select[name=video-input] option')!,
+      )
+      expect(options.map(o => o.getAttribute('value'))).toEqual([
+        DEVICE_DISABLED_ID,
+        DEVICE_DEFAULT_ID,
+        '456',
+      ])
+      expect(options.map(o => o.textContent!.trim())).toEqual([
+        'No Video',
+        'Default Video',
+        'Video Input',
+      ])
     })
   })
 

--- a/src/client/components/Media.tsx
+++ b/src/client/components/Media.tsx
@@ -266,7 +266,7 @@ function Options(props: OptionsProps) {
         .map(device =>
           <option
             key={device.id}
-            value={JSON.stringify({deviceId: device.id})}
+            value={device.id}
           >
             {device.name || device.type}
           </option>,

--- a/src/client/components/Toolbar.test.tsx
+++ b/src/client/components/Toolbar.test.tsx
@@ -20,6 +20,7 @@ import { insertableStreamsCodec } from '../insertable-streams'
 import { makeAction } from '../async'
 
 import { MediaConstraint } from '../reducers/media'
+import { blackTrack } from '../__mocks__/window'
 
 interface StreamState {
   cameraStream: LocalStream | null
@@ -432,11 +433,22 @@ describe('components/Toolbar track dropdowns', () => {
         describe('new track', () => {
           it('replaces peer track with new track in same stream', async () => {
             TestUtils.Simulate.click(devices[2])
+
+            // blank track
             await promise
+            ;[promise, resolve] = deferred<void>()
+
+            // new track
+            await promise
+
             const replaceTrack =
               store.getState().peers[peerId].replaceTrack as jest.Mock
-            expect(replaceTrack.mock.calls)
-            .toEqual([[ oldTrack, videoTrack, stream ]])
+
+            expect(JSON.stringify(replaceTrack.mock.calls))
+            .toEqual(JSON.stringify([
+              [ oldTrack, blackTrack, stream ],
+              [ blackTrack, videoTrack, stream ],
+            ]))
           })
         })
 
@@ -473,11 +485,21 @@ describe('components/Toolbar track dropdowns', () => {
             const quality = getQualityButtons()
             expect(quality.length).toBe(4)
             TestUtils.Simulate.click(quality[0])
+
+            // blank track
             await promise
+            ;[promise, resolve] = deferred<void>()
+
+            // new track
+            await promise
+
             const replaceTrack =
               store.getState().peers[peerId].replaceTrack as jest.Mock
-            expect(replaceTrack.mock.calls)
-            .toEqual([[ oldTrack, videoTrack, stream ]])
+            expect(JSON.stringify(replaceTrack.mock.calls))
+            .toEqual(JSON.stringify([
+              [ oldTrack, blackTrack, stream ],
+              [ blackTrack, videoTrack, stream ],
+            ]))
             expect(store.getState().media.video).toEqual({
               constraints: {
                 facingMode: 'user',

--- a/src/client/reducers/media.ts
+++ b/src/client/reducers/media.ts
@@ -124,7 +124,6 @@ export function handlePlay(
         autoplayError: false,
       }
     case 'rejected':
-      console.log('play rejected', action.payload.name)
       if (action.payload.name !== 'NotAllowedError') {
         return state
       }

--- a/src/client/window.ts
+++ b/src/client/window.ts
@@ -23,6 +23,10 @@ export interface PeerConfig {
 
 export const config: ClientConfig  = JSON.parse(valueOf('config')!)
 
+interface CanvasElement extends HTMLCanvasElement {
+  captureStream(): MediaStream
+}
+
 export const MediaStream = window.MediaStream
 export const MediaStreamTrack = window.MediaStreamTrack
 export const RTCRtpReceiver = window.RTCRtpReceiver
@@ -31,3 +35,27 @@ export const AudioContext = window.AudioContext
 export const AudioWorkletNode = window.AudioWorkletNode
 
 export const localStorage = window.localStorage
+
+// createBlackVideoTrack is in window so it can be easily mocked, for example
+// jest requires canvas, which requires python to be installed, and that's
+// just too much for a simple workaround.
+//
+// Idea from: https://blog.mozilla.org/webrtc/warm-up-with-replacetrack/
+export const createBlackVideoTrack = (
+  width: number,
+  height: number,
+) => {
+  const canvas = document.createElement('canvas') as CanvasElement
+
+  canvas.width = width
+  canvas.height = height
+
+  canvas.getContext('2d')!.fillRect(0, 0, width, height)
+
+  const stream = canvas.captureStream()
+
+  const [track] = stream.getVideoTracks()
+
+  return track
+}
+


### PR DESCRIPTION
The value of an `<option>` element was incorrectly being set as a JSON. This bug was most likely introduced in b35fdb6b.

Also run `npm audit fix`.

Closes #228.