### PR TITLE
Do not hardcode a list of ICE servers

### DIFF
--- a/server/configread.go
+++ b/server/configread.go
@@ -38,11 +38,7 @@ func InitConfig(c *Config) {
 	c.BindPort = 3000
 	c.Network.Type = NetworkTypeMesh
 	c.Store.Type = StoreTypeMemory
-	c.ICEServers = []ICEServer{{
-		URLs: []string{"stun:stun.l.google.com:19302"},
-	}, {
-		URLs: []string{"stun:global.stun.twilio.com:3478?transport=udp"},
-	}}
+	c.ICEServers = []ICEServer{}
 }
 
 func ReadConfig(filenames []string) (c Config, err error) {

--- a/server/configread_test.go
+++ b/server/configread_test.go
@@ -14,9 +14,8 @@ import (
 func TestReadConfig(t *testing.T) {
 	c, err := server.ReadConfig([]string{})
 	assert.Nil(t, err, "error reading config")
-	assert.Equal(t, 2, len(c.ICEServers))
-	assert.Equal(t, []string{"stun:stun.l.google.com:19302"}, c.ICEServers[0].URLs)
-	assert.Equal(t, []string{"stun:global.stun.twilio.com:3478?transport=udp"}, c.ICEServers[1].URLs)
+	assert.Equal(t, 0, len(c.ICEServers))
+	assert.NotNil(t, c.ICEServers)
 	assert.Equal(t, server.NetworkTypeMesh, c.Network.Type)
 	assert.Equal(t, server.StoreTypeMemory, c.Store.Type)
 }

--- a/server/iceauth.go
+++ b/server/iceauth.go
@@ -8,11 +8,14 @@ import (
 	"time"
 )
 
-func GetICEAuthServers(servers []ICEServer) (result []ICEAuthServer) {
-	for _, server := range servers {
-		result = append(result, newICEServer(server))
+func GetICEAuthServers(servers []ICEServer) []ICEAuthServer {
+	result := make([]ICEAuthServer, len(servers))
+
+	for i, server := range servers {
+		result[i] = newICEServer(server)
 	}
-	return
+
+	return result
 }
 
 func newICEServer(server ICEServer) ICEAuthServer {


### PR DESCRIPTION
Users should explicitly specify which one to use.

Another point of this change is to allow the users to test ICE-TCP candidates without the use of any ICE servers.

Example:

```bash
# build assets
npm run build

# start the main server as a SFU and enable only tcp4 protocol
PEERCALLS_FS=. PEERCALLS_NETWORK_TYPE=sfu PEERCALLS_NETWORK_SFU_PROTOCOLS=tcp4 go run ./main.go
```

The connection is established from Firefox using only the ICE-TCP candidate:

![image](https://user-images.githubusercontent.com/1489493/126594510-f077ffc2-a4a2-44cc-a57f-772ed5877344.png)

Closes #234.