### PR TITLE
Fix docker version

### DIFF
--- a/.github/workflows/v4.yml
+++ b/.github/workflows/v4.yml
@@ -115,11 +115,12 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs:
-      - build
+      - nodejs
+      - go
     steps:
     - uses: actions/checkout@v2
     - name: Build image
-      run: docker build . --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+      run: docker build . --build-arg VERSION="$(git describe --always --tags --dirty)" --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
     - name: Log in to registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
     - name: Push image

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN set -ex \
 COPY                  ./          /src/
 COPY --from=frontend  /src/build/ /src/build/
 
+ARG VERSION
+
 RUN set -ex \
  && go build \
       -ldflags "-X main.GitDescribe=$(git describe --always --tags --dirty)" \


### PR DESCRIPTION
The problem was that `git describe` would always result with a `-dirty`
suffix because we wouldn't include `Dockerfile` and `build/.gitkeep` in
the docker build context.

We don't really want to include `Dockerfile` because any change to it
would invalidate the build cache, and we don't want that.Jeremija/docker versio

So instead of using `git describe` within the docker build context, we
pass the VERSION using `--build-arg` parameter.
