### PR TITLE
Disable insertable streams by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ docker run --rm -it -p 3000:3000 peer-calls
 | `PEERCALLS_ICE_SERVER_SECRET`        | string | Secret for coturn                                                            |           |
 | `PEERCALLS_ICE_SERVER_USERNAME`      | string | Username for coturn                                                          |           |
 | `PEERCALLS_PROMETHEUS_ACCESS_TOKEN`  | string | Access token for prometheus `/metrics` URL                                   |           |
+| `PEERCALLS_FRONTEND_ENCODED_INSERTABLE_STREAMS` | bool | Enable insertable streams                                           | `false`   |
 
 The default ICE servers in use are:
 
@@ -222,6 +223,8 @@ network:
   #   - eth0
 prometheus:
   access_token: "mytoken"
+frontend:
+  encodedInsertableStreams: false
 ```
 
 Prometheus `/metrics` URL will not be accessible without an access token set.

--- a/server/cli/server.go
+++ b/server/cli/server.go
@@ -110,7 +110,9 @@ func (h *serverHandler) configure() (err error) {
 	})
 	rooms, _ := roomManagerFactory.NewRoomManager(c.Network)
 
-	h.mux = server.NewMux(log, c.BaseURL, h.props.Version, c.Network, c.ICEServers, rooms, tracks, c.Prometheus, h.props.Embed)
+	encodedInsertableStreams := c.Frontend.EncodedInsertableStreams
+
+	h.mux = server.NewMux(log, c.BaseURL, h.props.Version, c.Network, c.ICEServers, encodedInsertableStreams, rooms, tracks, c.Prometheus, h.props.Embed)
 
 	return nil
 }

--- a/server/configread.go
+++ b/server/configread.go
@@ -99,6 +99,8 @@ func ReadConfigFromEnv(prefix string, c *Config) {
 	}
 
 	setEnvString(&c.Prometheus.AccessToken, prefix+"PROMETHEUS_ACCESS_TOKEN")
+
+	setEnvBool(&c.Frontend.EncodedInsertableStreams, prefix+"FRONTEND_ENCODED_INSERTABLE_STREAMS")
 }
 
 func setEnvSlice(dest *[]string, name string) {

--- a/server/configtypes.go
+++ b/server/configtypes.go
@@ -78,6 +78,7 @@ type Config struct {
 	BaseURL  string `yaml:"base_url"`
 	BindHost string `yaml:"bind_host"`
 	BindPort int    `yaml:"bind_port"`
+
 	// When FS is non empty, it will be used as a root path to the resource files.
 	FS         string           `yaml:"fs"`
 	ICEServers []ICEServer      `yaml:"ice_servers"`
@@ -85,6 +86,12 @@ type Config struct {
 	Store      StoreConfig      `yaml:"store"`
 	Network    NetworkConfig    `yaml:"network"`
 	Prometheus PrometheusConfig `yaml:"prometheus"`
+
+	Frontend Frontend `yaml:"frontend"`
+}
+
+type Frontend struct {
+	EncodedInsertableStreams bool `yaml:"encodedInsertableStreams"`
 }
 
 type ICEAuthServer struct {
@@ -94,10 +101,15 @@ type ICEAuthServer struct {
 }
 
 type ClientConfig struct {
-	BaseURL    string          `json:"baseUrl"`
-	Nickname   string          `json:"nickname"`
-	CallID     string          `json:"callId"`
-	PeerID     string          `json:"peerId"`
-	ICEServers []ICEAuthServer `json:"iceServers"`
-	Network    NetworkType     `json:"network"`
+	BaseURL    string      `json:"baseUrl"`
+	Nickname   string      `json:"nickname"`
+	CallID     string      `json:"callId"`
+	PeerID     string      `json:"peerId"`
+	PeerConfig PeerConfig  `json:"peerConfig"`
+	Network    NetworkType `json:"network"`
+}
+
+type PeerConfig struct {
+	ICEServers               []ICEAuthServer `json:"iceServers"`
+	EncodedInsertableStreams bool            `json:"encodedInsertableStreams"`
 }

--- a/server/mux_test.go
+++ b/server/mux_test.go
@@ -82,7 +82,7 @@ func Test_routeIndex(t *testing.T) {
 	trk := newMockTracksManager()
 	prom := server.PrometheusConfig{"test1234"}
 	defer mrm.close()
-	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, mrm, trk, prom, embed)
+	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, false, mrm, trk, prom, embed)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/test", nil)
 
@@ -96,7 +96,7 @@ func Test_routeIndex_noBaseURL(t *testing.T) {
 	mrm := NewMockRoomManager()
 	trk := newMockTracksManager()
 	defer mrm.close()
-	mux := server.NewMux(test.NewLogger(), "", "v0.0.0", mesh(), iceServers, mrm, trk, prom(), embed)
+	mux := server.NewMux(test.NewLogger(), "", "v0.0.0", mesh(), iceServers, false, mrm, trk, prom(), embed)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/", nil)
 
@@ -110,7 +110,7 @@ func Test_routeNewCall_name(t *testing.T) {
 	mrm := NewMockRoomManager()
 	trk := newMockTracksManager()
 	defer mrm.close()
-	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, mrm, trk, prom(), embed)
+	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, false, mrm, trk, prom(), embed)
 	w := httptest.NewRecorder()
 	reader := strings.NewReader("call=my room")
 	r := httptest.NewRequest("POST", "/test/call", reader)
@@ -126,7 +126,7 @@ func Test_routeNewCall_random(t *testing.T) {
 	mrm := NewMockRoomManager()
 	trk := newMockTracksManager()
 	defer mrm.close()
-	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, mrm, trk, prom(), embed)
+	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, false, mrm, trk, prom(), embed)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("POST", "/test/call", nil)
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -145,7 +145,7 @@ func Test_routeCall(t *testing.T) {
 	iceServers := []server.ICEServer{{
 		URLs: []string{"stun:"},
 	}}
-	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, mrm, trk, prom(), embed)
+	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, false, mrm, trk, prom(), embed)
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/test/call/abc", nil)
 	mux.ServeHTTP(w, r)
@@ -162,7 +162,8 @@ func Test_routeCall(t *testing.T) {
 	assert.Equal(t, "", config.Nickname)
 	assert.Equal(t, "abc", config.CallID)
 	assert.NotEmpty(t, config.PeerID)
-	assert.NotEmpty(t, config.ICEServers)
+	assert.NotEmpty(t, config.PeerConfig.ICEServers)
+	assert.False(t, config.PeerConfig.EncodedInsertableStreams)
 	assert.Equal(t, server.NetworkTypeMesh, config.Network)
 }
 
@@ -170,7 +171,7 @@ func Test_manifest(t *testing.T) {
 	mrm := NewMockRoomManager()
 	trk := newMockTracksManager()
 	defer mrm.close()
-	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, mrm, trk, prom(), embed)
+	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, false, mrm, trk, prom(), embed)
 	w := httptest.NewRecorder()
 	reader := strings.NewReader("call=my room")
 	r := httptest.NewRequest("GET", "/test/manifest.json", reader)
@@ -185,7 +186,7 @@ func Test_Metrics(t *testing.T) {
 	mrm := NewMockRoomManager()
 	trk := newMockTracksManager()
 	defer mrm.close()
-	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, mrm, trk, prom(), embed)
+	mux := server.NewMux(test.NewLogger(), "/test", "v0.0.0", mesh(), iceServers, false, mrm, trk, prom(), embed)
 
 	for _, testCase := range []struct {
 		statusCode    int

--- a/src/client/__mocks__/window.ts
+++ b/src/client/__mocks__/window.ts
@@ -78,7 +78,10 @@ export const config: ClientConfig = {
   baseUrl: '',
   callId: 'call1234',
   peerId: 'user1234',
-  iceServers: [],
+  peerConfig: {
+    iceServers: [],
+    encodedInsertableStreams: true,
+  },
   network: 'sfu',
   nickname: 'nick1234',
 }

--- a/src/client/actions/PeerActions.ts
+++ b/src/client/actions/PeerActions.ts
@@ -12,7 +12,7 @@ import { addMessage } from './ChatActions'
 import * as NotifyActions from './NotifyActions'
 import * as StreamActions from './StreamActions'
 
-const { iceServers } = config
+const { peerConfig } = config
 
 const debug = _debug('peercalls')
 const sdpDebug = _debug('peercalls:sdp')
@@ -160,17 +160,19 @@ export function createPeer (options: CreatePeerOptions) {
       dispatch(removePeer(peerId))
     }
 
-    debug('Using ice servers: %o', iceServers)
+    debug('Using ice servers: %o', peerConfig.iceServers)
 
     const pc = new Peer({
       initiator,
       config: {
-        iceServers,
-        encodedInsertableStreams: true,
+        iceServers: peerConfig.iceServers,
+        encodedInsertableStreams: peerConfig.encodedInsertableStreams,
         // legacy flags for insertable streams
-        enableInsertableStreams: true,
-        forceEncodedVideoInsertableStreams: true,
-        forceEncodedAudioInsertableStreams: true,
+        enableInsertableStreams: peerConfig.encodedInsertableStreams,
+        forceEncodedVideoInsertableStreams:
+          peerConfig.encodedInsertableStreams,
+        forceEncodedAudioInsertableStreams:
+          peerConfig.encodedInsertableStreams,
       },
       channelName: constants.PEER_DATA_CHANNEL_NAME,
       // trickle: false,

--- a/src/client/components/Toolbar.tsx
+++ b/src/client/components/Toolbar.tsx
@@ -185,46 +185,49 @@ export default class Toolbar extends React.PureComponent<
             </React.Fragment>
           )}
 
-          <div className='encryption-wrapper'>
-            <ToolbarButton
-              onClick={this.toggleEncryptionDialog}
-              key='encryption'
-              className={classnames('encryption', {
-                'encryption-enabled': this.state.encrypted,
-              })}
-              on={this.state.encryptionDialogVisible || this.state.encrypted}
-              icon={encryptionIcon}
-              title='Setup Encryption'
-            />
-            <div
-              className={classnames('encryption-dialog', {
-                'encryption-dialog-visible': this.state.encryptionDialogVisible,
-              })}
-            >
-              <div className='encryption-form'>
-                <input
-                  autoComplete='off'
-                  name='encryption-key'
-                  className='encryption-key'
-                  placeholder='Enter Passphrase'
-                  ref={this.encryptionKeyInputRef}
-                  type='password'
-                  onKeyUp={this.setPasswordOnEnter}
-                />
-                <button onClick={this.setPassword}>Save</button>
+          {config.peerConfig.encodedInsertableStreams && (
+            <div className='encryption-wrapper'>
+              <ToolbarButton
+                onClick={this.toggleEncryptionDialog}
+                key='encryption'
+                className={classnames('encryption', {
+                  'encryption-enabled': this.state.encrypted,
+                })}
+                on={this.state.encryptionDialogVisible || this.state.encrypted}
+                icon={encryptionIcon}
+                title='Setup Encryption'
+              />
+              <div
+                className={classnames('encryption-dialog', {
+                  'encryption-dialog-visible':
+                    this.state.encryptionDialogVisible,
+                })}
+              >
+                <div className='encryption-form'>
+                  <input
+                    autoComplete='off'
+                    name='encryption-key'
+                    className='encryption-key'
+                    placeholder='Enter Passphrase'
+                    ref={this.encryptionKeyInputRef}
+                    type='password'
+                    onKeyUp={this.setPasswordOnEnter}
+                  />
+                  <button onClick={this.setPassword}>Save</button>
+                </div>
+                <div className='note'>
+                  <p><MdWarning /> Experimental functionality for A/V only.</p>
+                  {!this.supportsInsertableStreams && (
+                    <p>
+                      Your browser does not support Insertable Streams;
+                      currently only Chrome has support. If you are using
+                      Chrome, please make sure Experimental Web Platform
+                      Features are enabled in chrome://flags.
+                    </p>
+                  )} </div>
               </div>
-              <div className='note'>
-                <p><MdWarning /> Experimental functionality for A/V only.</p>
-                {!this.supportsInsertableStreams && (
-                  <p>
-                    Your browser does not support Insertable Streams;
-                    currently only Chrome has support. If you are using Chrome,
-                    please make sure Experimental Web Platform Features are
-                    enabled in chrome://flags.
-                  </p>
-                )} </div>
             </div>
-          </div>
+          )}
 
         </div>
 

--- a/src/client/index-simple.tsx
+++ b/src/client/index-simple.tsx
@@ -2,50 +2,88 @@ import Peer from 'simple-peer'
 import socket from './socket'
 import { config } from './window'
 
-const { iceServers, peerId, callId } = config
+const { peerConfig, peerId, callId } = config
+
+const { iceServers, encodedInsertableStreams } = peerConfig
 
 const $container = document.getElementById('container')!
 socket.reconnectTimeout = 0
 
 socket.on('connect', () => {
-
   socket.on('users', ({initiator, peerIds}) => {
-    const peer = new Peer({
-      initiator: initiator === peerId,
-      config: { iceServers },
-      trickle: false,
-      // Allow the peer to receive video, even if it's not sending stream:
-      // https://github.com/feross/simple-peer/issues/95
-      //offerConstraints: {
-      //  offerToReceiveAudio: true,
-      //  offerToReceiveVideo: true,
-      //},
-    })
+    console.log('users', peerIds)
 
-    peer.on('signal', signal => {
-      socket.emit('signal', {
-        peerId,
-        signal,
+    peerIds.forEach(remotePeerId => {
+      if (peerId === remotePeerId) {
+        console.log('skipping current user', peerIds)
+
+        return
+      }
+
+      const peer = new Peer({
+        initiator: initiator === remotePeerId,
+        config: { iceServers, encodedInsertableStreams },
+        trickle: false,
+        // Allow the peer to receive video, even if it's not sending stream:
+        // https://github.com/feross/simple-peer/issues/95
+        //offerConstraints: {
+        //  offerToReceiveAudio: true,
+        //  offerToReceiveVideo: true,
+        //},
       })
-    })
 
-    socket.on('signal', payload => {
-      peer.signal(payload.signal)
-    })
+      peer.on('signal', signal => {
+        console.log('signal', signal)
 
-
-    // ;(peer as any).addTransceiver('video', {
-    //   direction:'sendonly',
-    // })
-
-    peer.on('connect', () => {
-      console.log('peer connect')
-      navigator.mediaDevices.getUserMedia({
-        video: true,
-        audio: false,
+        socket.emit('signal', {
+          peerId: remotePeerId,
+          signal,
+        })
       })
-      .then(stream => {
-        const el = document.createElement('video')
+
+      socket.on('signal', payload => {
+        peer.signal(payload.signal)
+      })
+
+
+      // ;(peer as any).addTransceiver('video', {
+      //   direction:'sendonly',
+      // })
+
+      peer.on('connect', () => {
+        console.log('peer connect')
+        navigator.mediaDevices.getUserMedia({
+          video: true,
+          audio: false,
+        })
+        .then(stream => {
+          const el = document.createElement('video')
+          el.style.width = '200px'
+          el.style.backgroundColor = '#555'
+          el.srcObject = stream
+          el.autoplay = true
+          el.controls = true
+          $container.appendChild(el)
+
+          stream.getTracks().forEach(track => {
+            console.log(
+              'local track', track.id, track.label,
+              'muted?', track.muted, 'enabled?', track.enabled)
+            peer.addTrack(track, stream)
+          })
+
+        })
+        .catch(err => {
+          console.error(err)
+        })
+      })
+
+      peer.on('track', (track: MediaStreamTrack, stream: MediaStream) => {
+        console.log(
+          'remote track', track.id, track.label,
+          'muted?', track.muted, 'enabled?', track.enabled)
+        track.enabled = true
+        const el = document.createElement(track.kind) as HTMLVideoElement
         el.style.width = '200px'
         el.style.backgroundColor = '#555'
         el.srcObject = stream
@@ -53,42 +91,19 @@ socket.on('connect', () => {
         el.controls = true
         $container.appendChild(el)
 
-        stream.getTracks().forEach(track => {
-          console.log(
-            'local track', track.id, track.label,
-            'muted?', track.muted, 'enabled?', track.enabled)
-          peer.addTrack(track, stream)
-        })
+        track.onunmute = function(event) {
+          console.log('track unmuted', track.id)
+        }
 
+        track.onmute = function(event) {
+          console.log('track muted', track.id)
+          $container.removeChild(el)
+        }
       })
-      .catch(err => {
-        console.error(err)
-      })
-    })
-
-    peer.on('track', (track: MediaStreamTrack, stream: MediaStream) => {
-      console.log(
-        'remote track', track.id, track.label,
-        'muted?', track.muted, 'enabled?', track.enabled)
-      track.enabled = true
-      const el = document.createElement(track.kind) as HTMLVideoElement
-      el.style.width = '200px'
-      el.style.backgroundColor = '#555'
-      el.srcObject = stream
-      el.autoplay = true
-      el.controls = true
-      $container.appendChild(el)
-
-      track.onunmute = function(event) {
-        console.log('track unmuted', track.id)
-      }
-
-      track.onmute = function(event) {
-        console.log('track muted', track.id)
-        $container.removeChild(el)
-      }
     })
   })
+
+  console.log('emitting ready')
 
   socket.emit('ready', {
     room: callId,

--- a/src/client/window.ts
+++ b/src/client/window.ts
@@ -12,8 +12,13 @@ export interface ClientConfig {
   nickname: string
   callId: string
   peerId: string
-  iceServers: RTCIceServer[]
+  peerConfig: PeerConfig
   network: 'mesh' | 'sfu'
+}
+
+export interface PeerConfig {
+  iceServers: RTCIceServer[]
+  encodedInsertableStreams: boolean
 }
 
 export const config: ClientConfig  = JSON.parse(valueOf('config')!)


### PR DESCRIPTION
Chrome started crashing with SIGSEGV when insertable streams were
enabled in Mesh network mode. Since the insertable streams only really
work on Chrome, it did not make sense to keep it enabled by default.
Also, the insertable streams currently only works with VP8 codec, it's
broken when using the H264, which is the default when SFU mode is
enabled.

Users who wish to enable insertable streams can do so by explicitly
setting the following environment variable:

    PEERCALLS_FRONTEND_ENCODED_INSERTABLE_STREAMS=true

Or the following YAML config option:

    frontend.encodedInsertableStreams: true

This is why corporations build their own native clients if they want to
support additional features.

Closes #263.