### PR TITLE
Fix panic: send on closed channel

### DIFF
--- a/server/transport/transport.go
+++ b/server/transport/transport.go
@@ -21,6 +21,8 @@ type Transport interface {
 
 	DataTransport
 
+	// RemoteTracksChannel might never be closed.
+	// Use Done() in select when reading from this channel to prevent deadlocks.
 	RemoteTracksChannel() <-chan TrackRemoteWithRTCPReader
 
 	LocalTracks() []TrackWithMID

--- a/server/webrtctransport.go
+++ b/server/webrtctransport.go
@@ -168,7 +168,6 @@ func RegisterCodecs(mediaEngine *webrtc.MediaEngine, registry *codecs.Registry) 
 
 type WebRTCTransport struct {
 	mu sync.RWMutex
-	wg sync.WaitGroup
 
 	log logger.Logger
 
@@ -319,10 +318,8 @@ func NewWebRTCTransport(
 	go func() {
 		// wait for peer connection to be closed
 		<-signaller.Done()
-		// do not close channels before all writing goroutines exit
-		transport.wg.Wait()
+		peerConnection.OnTrack(nil)
 		transport.dataTransceiver.Close()
-		close(transport.remoteTracksChannel)
 	}()
 	return transport, nil
 }


### PR DESCRIPTION
    panic: send on closed channel
    goroutine 3524463 [running]:
    github.com/peer-calls/peer-calls/server.(*WebRTCTransport).handleTrack(0xc0038e4ea0, 0xc0032337a0, 0xc0066949c0)
     /home/runner/work/peer-calls/peer-calls/server/webrtctransport.go:497 +0x36c
    created by github.com/pion/webrtc/v3.(*PeerConnection).onTrack
     /home/runner/go/pkg/mod/github.com/pion/webrtc/v3@v3.0.18/peerconnection.go:451 +0x10f